### PR TITLE
Fix min-height and text sizes to fit TV with high scale

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import TopFarmers from "./component/TopFarmers";
 // todo dynamic width/height based on whichever is narrower on screen
 
 type GraphType = "TAU7D" | "WeeklyCadetXp";
-type ViewType = "TV" | "Desktop" | "Tablet" | "Mobile" | "";
+type ViewType = "Desktop" | "Laptop" | "Tablet" | "Mobile" | "";
 
 function App() {
   const divRef = useRef<HTMLDivElement | null>(null);
@@ -43,8 +43,8 @@ function App() {
   useEffect(() => {
     if (divRef.current) {
       const width = divRef.current.clientWidth;
-      if (width >= 2560) setViewType("TV");
-      else if (width >= 1280 && width < 2560) setViewType("Desktop");
+	  if (width >= 1900) setViewType("Desktop")
+      else if (width >= 1280 && width < 1900) setViewType("Laptop");
       else if (width >= 736 && width < 1280) setViewType("Tablet");
       else setViewType("Mobile");
     }
@@ -85,10 +85,10 @@ function App() {
       className="w-screen h-fit md:h-screen flex flex-col items-center justify-start bg-gray-800 text-center text-base overflow-y-auto"
       ref={divRef}
     >
-      <div className="flex w-full flex-col items-center justify-center bg-gray-900 py-3 text-3xl text-white">
+      <div className="flex w-full flex-col items-center justify-center bg-gray-900 py-3 text-xl 2xl:text-2xl 3xl:text-3xl font-semibold text-white">
         <h1>Live Stats: 42 Kuala Lumpur</h1>
       </div>
-      <div className="w-full lg:w-[95%] xl:w-[90%] h-[2560px] md:h-full md:min-h-[1280px] xl:min-h-[780px] grid grid-flow-col grid-cols-1 grid-rows-[repeat(34,minmax(0,1fr))] md:grid-cols-2 md:grid-rows-[repeat(20,minmax(0,1fr))] xl:grid-cols-5 xl:grid-rows-[repeat(12,minmax(0,1fr))] p-2 md:p-4 2xl:p-6 gap-3 xl:gap-4 2xl:gap-5">
+      <div className="w-full lg:w-[95%] 2xl:w-[90%] h-[2560px] md:h-full md:min-h-[1280px] xl:min-h-[668px] grid grid-flow-col grid-cols-1 grid-rows-[repeat(34,minmax(0,1fr))] md:grid-cols-2 md:grid-rows-[repeat(20,minmax(0,1fr))] xl:grid-cols-5 xl:grid-rows-[repeat(12,minmax(0,1fr))] p-2 md:p-4 2xl:p-6 3xl:p-10 gap-3 2xl:gap-4 3xl:gap-5">
         <ActiveUserProjects
           className="row-span-5 md:row-span-6 md:col-span-1 xl:col-span-2"
           viewType={viewType}

--- a/frontend/src/component/ActiveUserProjects.tsx
+++ b/frontend/src/component/ActiveUserProjects.tsx
@@ -129,16 +129,10 @@ function ChartLegends({
             ></circle>
             <text
               className={
-                viewType === "TV"
-                  ? "text-lg"
-                  : viewType === "Desktop"
-                  ? project.length > 24
-                    ? "text-sm"
-                    : "text-base"
-                  : project.length > 24
-                  ? "text-xs"
-                  : "text-sm"
-              } // scale text if (1) larger on desktop devices; (2) project name is too long
+				viewType === "Desktop" ? (
+					project.length > 32 ? "text-sm" : "text-base"
+				) : (project.length > 32 ? "text-xs" : "text-sm")
+              } // scale text if project name is too long
               x="16"
               y={legendMargin * i}
               style={{ fill: "#f3f4f6" }}
@@ -202,7 +196,7 @@ export default function ActiveUserProjects(props: TPropsType) {
     if (childRef.current) {
       const width = childRef.current.clientWidth;
       const height = childRef.current.clientHeight;
-      const radius = Math.round(width * 0.18);
+      const radius = Math.round(width * 0.175);
       const pieOffset = Math.round(radius * 1.1); // pie chart offset along the x-axis
       const legendOffset = Math.round(pieOffset * 2.1); // pie legend offset along the x-axis
       setDimension({

--- a/frontend/src/component/ActiveUserProjects.tsx
+++ b/frontend/src/component/ActiveUserProjects.tsx
@@ -130,14 +130,14 @@ function ChartLegends({
             <text
               className={
 				viewType === "Desktop" ? (
-					project.length > 32 ? "text-sm" : "text-base"
-				) : (project.length > 32 ? "text-xs" : "text-sm")
+					project.length > 28 ? "text-sm" : "text-base"
+				) : (project.length > 28 ? "text-xs" : "text-sm")
               } // scale text if project name is too long
               x="16"
               y={legendMargin * i}
               style={{ fill: "#f3f4f6" }}
             >
-              {project + " (" + percentage + ")"}
+              {project + " (" + parseFloat(percentage).toFixed(1) + "%)"}
             </text>
           </g>
         )

--- a/frontend/src/component/AverageLevel.tsx
+++ b/frontend/src/component/AverageLevel.tsx
@@ -30,7 +30,7 @@ const AverageLevel = ({ className }: { className: string }) => {
     <Card className={className + " flex flex-col"}>
       <CardTitle>Average level</CardTitle>
       {averageLvl ? (
-        <div className="text-4xl 2xl:text-6xl h-full align-middle flex justify-center items-center">
+        <div className="text-5xl xl:text-4xl 2xl:text-6xl h-full align-middle flex justify-center items-center">
           {averageLvl}
         </div>
       ) : (

--- a/frontend/src/component/AverageLevel.tsx
+++ b/frontend/src/component/AverageLevel.tsx
@@ -30,7 +30,7 @@ const AverageLevel = ({ className }: { className: string }) => {
     <Card className={className + " flex flex-col"}>
       <CardTitle>Average level</CardTitle>
       {averageLvl ? (
-        <div className="text-5xl md:text-6xl h-full align-middle flex justify-center items-center">
+        <div className="text-4xl 2xl:text-6xl h-full align-middle flex justify-center items-center">
           {averageLvl}
         </div>
       ) : (

--- a/frontend/src/component/AverageSessionTime.tsx
+++ b/frontend/src/component/AverageSessionTime.tsx
@@ -34,7 +34,7 @@ const AverageSessionTime = ({ className }: IAverageSessionTimeProps) => {
     <Card className={className + " flex flex-col"}>
       <CardTitle>Average session time</CardTitle>
       {averageSessionTime ? (
-        <div className="text-4xl 2xl:text-6xl h-full align-middle flex flex-col justify-center items-center">
+        <div className="text-5xl xl:text-4xl 2xl:text-6xl h-full align-middle flex flex-col justify-center items-center">
           {averageSessionTime}hr
         </div>
       ) : (

--- a/frontend/src/component/AverageSessionTime.tsx
+++ b/frontend/src/component/AverageSessionTime.tsx
@@ -34,7 +34,7 @@ const AverageSessionTime = ({ className }: IAverageSessionTimeProps) => {
     <Card className={className + " flex flex-col"}>
       <CardTitle>Average session time</CardTitle>
       {averageSessionTime ? (
-        <div className="text-5xl md:text-6xl h-full align-middle flex flex-col justify-center items-center">
+        <div className="text-4xl 2xl:text-6xl h-full align-middle flex flex-col justify-center items-center">
           {averageSessionTime}hr
         </div>
       ) : (

--- a/frontend/src/component/CardTitle.tsx
+++ b/frontend/src/component/CardTitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const CardTitle = ({ children }: { children: React.ReactNode }) => {
-    return <h1 className="mb-2 rounded bg-gray-600 p-1 text-lg text-gray-100">{children}</h1>;
+    return <h1 className="mb-2 rounded bg-gray-600 p-1 text-base 2xl:text-lg 3xl:text-xl font-medium text-gray-100">{children}</h1>;
 };
 
 export default CardTitle;

--- a/frontend/src/component/CurrentActiveUser.tsx
+++ b/frontend/src/component/CurrentActiveUser.tsx
@@ -78,7 +78,7 @@ function CurrentActiveUser({
           }
           style={{ width: `${imageSize}px`, height: `${imageSize}px` }}
         />
-        <p className="text-sm xl:text-base 3xl:text-lg">{singleUser.login}</p>
+        <p className="text-xs xl:text-sm 2xl:text-base 3xl:text-lg">{singleUser.login}</p>
       </div>
     );
   });

--- a/frontend/src/component/MostActiveUsers.tsx
+++ b/frontend/src/component/MostActiveUsers.tsx
@@ -87,7 +87,7 @@ const MostActiveUsers = ({ className }: IMostActiveUsers) => {
       <div className="w-full h-full" ref={childRef}>
         {imageSize !== 0 &&
           (data ? (
-            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center">
+            <div className="grid grid-cols-5 h-full basis-0 grow shrink w-full items-center justify-around">
               {data.map((item: any, index: number) => (
                 <ColumnComponent
                   key={index}

--- a/frontend/src/component/MostActiveUsers.tsx
+++ b/frontend/src/component/MostActiveUsers.tsx
@@ -87,7 +87,7 @@ const MostActiveUsers = ({ className }: IMostActiveUsers) => {
       <div className="w-full h-full" ref={childRef}>
         {imageSize !== 0 &&
           (data ? (
-            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center p-0 md:p-1 lg:p-2 xl:p-3">
+            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center">
               {data.map((item: any, index: number) => (
                 <ColumnComponent
                   key={index}

--- a/frontend/src/component/MostRecentSubmission.tsx
+++ b/frontend/src/component/MostRecentSubmission.tsx
@@ -52,11 +52,11 @@ function ProjectContainer({
       </div>
       <p className="text-base">{name}</p>
       <div className="text-sm 3xl:text-lg inline-flex items-center">
-        <span className="text-lg 3xl:text-2xl font-semibold text-green-500">
+        <span className="text-base 2xl:text-lg 3xl:text-2xl font-semibold text-green-500">
           {score}
         </span>
         /100
-        <p className="text-sm 3xl:text-lg text-gray-400 ml-3">{time_string}</p>
+        <p className="text-xs 2xl:text-sm 3xl:text-lg text-gray-400 ml-3">{time_string}</p>
       </div>
     </div>
   );
@@ -114,7 +114,7 @@ const MostRecentSubmission = ({ className }: IMostRecentSubmissionProps) => {
       <div className="w-full h-full" ref={childRef}>
         {imageSize !== 0 &&
           (data ? (
-            <div className="h-full flex flex-col items-center justify-around gap-5 align-middle text-6xl">
+            <div className="h-full flex flex-col items-center justify-around text-6xl">
               {data.map((item: any, index: number) => (
                 <ProjectContainer
                   key={index}

--- a/frontend/src/component/TopFarmers.tsx
+++ b/frontend/src/component/TopFarmers.tsx
@@ -107,7 +107,7 @@ const TopFarmers = ({ className }: ITopFarmers) => {
       <div className="w-full h-full" ref={childRef}>
         {imageSize !== 0 &&
           (data ? (
-            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center">
+            <div className="grid grid-cols-5 h-full basis-0 grow shrink w-full items-center justify-around">
               {data.map((item: any, index: number) => (
                 <ColumnComponent
                   key={index}

--- a/frontend/src/component/TopFarmers.tsx
+++ b/frontend/src/component/TopFarmers.tsx
@@ -107,7 +107,7 @@ const TopFarmers = ({ className }: ITopFarmers) => {
       <div className="w-full h-full" ref={childRef}>
         {imageSize !== 0 &&
           (data ? (
-            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center p-0 md:p-1 lg:p-2 xl:p-3">
+            <div className="grid grid-cols-5 gap-6 h-full basis-0 grow shrink w-full items-center justify-center">
               {data.map((item: any, index: number) => (
                 <ColumnComponent
                   key={index}

--- a/frontend/src/component/UserContainer.tsx
+++ b/frontend/src/component/UserContainer.tsx
@@ -20,8 +20,8 @@ const UserContainer = ({
         src={imgSrc}
         alt="user"
       />
-      <p className="text-sm xl:text-base 3xl:text-lg">{login}</p>
-      <b className="text-base xl:text-lg 3xl:text-2xl">{extra}</b>
+      <p className="text-sm 2xl:text-base 3xl:text-lg">{login}</p>
+      <b className="text-base 2xl:text-lg 3xl:text-2xl">{extra}</b>
     </div>
   );
 };


### PR DESCRIPTION
Apparently TV browser viewport is only 720p :/

## Fix
1. Change min-height to suit TV viewport
2. Resize text dynamically
3. Remove gap prop in ColumnContainer inside `MostActiveUsers` and `TopFarmer`, change to justify-around
4. Round percentage to 1 decimals in `CurrentActiveProject` pie legend

chipi chipi chapa chapa